### PR TITLE
Feature/amend pom compiler utf 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -8,30 +8,17 @@
     <artifactId>lakesideresort</artifactId>
     <version>0.1.0-SNAPSHOT</version>
 
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
 
     <dependencies>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
-
 </project>


### PR DESCRIPTION
Heren, dame,

Even dit aangepast, zodat Maven en ... niet over de versie zeurt en dat UTF-8 encoding zonder
warning in Maven voorbij komt.

De setting via de compiler plugin is ook OK hoor maar dan moet je de versie meer bijhouden.